### PR TITLE
Exit command changed from [shift+q] to [ctrl+shift+q].

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       font-family: Arvo;
       font-weight: normal;
       text-align:center;
-      font-size:30vw;
+      font-size:35vw;
     }
     #instructions {
       position: absolute;

--- a/index.html
+++ b/index.html
@@ -10,10 +10,10 @@
       font-family: Dosis, sans-serif;
     }
     #key {
-      font-family: Bangers;
+      font-family: Arvo;
       font-weight: normal;
       text-align:center;
-      font-size:60vw;
+      font-size:30vw;
     }
     #instructions {
       position: absolute;
@@ -21,11 +21,11 @@
       left: 10px;
     }
     </style>
-    <link href="https://fonts.googleapis.com/css?family=Bangers" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Arvo" rel="stylesheet">
   </head>
   <body>
 <div id="key"></div>
-<div id="instructions">Shift+Q to close</div>
+<div id="instructions">Ctrl+Shift+Q to close</div>
 <script src="mousetrap.min.js"></script>
 <script src="renderer.js"></script>
   </body>

--- a/renderer.js
+++ b/renderer.js
@@ -1,5 +1,5 @@
 Mousetrap.bind('ctrl+shift+q', function() {
-    window.close();
+    window.closeCurrentWindow();
 });
 
 colorMap = {0: "red", 1: "orange", 2: "gold", 3: "green", 4: "blue", 5: "indigo", 6: "violet"}

--- a/renderer.js
+++ b/renderer.js
@@ -2,7 +2,7 @@ Mousetrap.bind('ctrl+shift+q', function() {
     window.closeCurrentWindow();
 });
 
-var colorMap = {0: 'red', 1: 'orange', 2: 'gold', 3: 'green', 4: 'blue', 5: 'indigo', 6: 'violet'}
+const colorMap = {0: 'red', 1: 'orange', 2: 'gold', 3: 'green', 4: 'blue', 5: 'indigo', 6: 'violet'}
 
 document.body.addEventListener('keydown', function(e) {
     e.preventDefault();

--- a/renderer.js
+++ b/renderer.js
@@ -2,17 +2,15 @@ Mousetrap.bind('ctrl+shift+q', function() {
     window.closeCurrentWindow();
 });
 
-colorMap = {0: "red", 1: "orange", 2: "gold", 3: "green", 4: "blue", 5: "indigo", 6: "violet"}
+var colorMap = {0: 'red', 1: 'orange', 2: 'gold', 3: 'green', 4: 'blue', 5: 'indigo', 6: 'violet'}
 
 document.body.addEventListener('keydown', function(e) {
     e.preventDefault();
     if (e.key.length < 2){
         charCode = e.key.charCodeAt(0);
-        document.getElementById("key").innerHTML = e.key;
-        color = colorMap[charCode % 7];
-        document.getElementById("key").style.color = color;
-    } else { 
-    	// Possibly handle non-character-keys differently.
+        document.getElementById('key').innerHTML = e.key;
+        const color = colorMap[charCode % 7];
+        document.getElementById('key').style.color = color;
     }
     return false;
 });

--- a/renderer.js
+++ b/renderer.js
@@ -7,8 +7,8 @@ var colorMap = {0: 'red', 1: 'orange', 2: 'gold', 3: 'green', 4: 'blue', 5: 'ind
 document.body.addEventListener('keydown', function(e) {
     e.preventDefault();
     if (e.key.length < 2){
-        charCode = e.key.charCodeAt(0);
         document.getElementById('key').innerHTML = e.key;
+	const charCode = e.key.charCodeAt(0);
         const color = colorMap[charCode % 7];
         document.getElementById('key').style.color = color;
     }

--- a/renderer.js
+++ b/renderer.js
@@ -1,8 +1,18 @@
-Mousetrap.bind('shift+q', function() {
-    window.closeCurrentWindow();
+Mousetrap.bind('ctrl+shift+q', function() {
+    window.close();
 });
+
+colorMap = {0: "red", 1: "orange", 2: "gold", 3: "green", 4: "blue", 5: "indigo", 6: "violet"}
+
 document.body.addEventListener('keydown', function(e) {
     e.preventDefault();
-    document.getElementById("key").innerHTML = e.key;
+    if (e.key.length < 2){
+        charCode = e.key.charCodeAt(0);
+        document.getElementById("key").innerHTML = e.key;
+        color = colorMap[charCode % 7];
+        document.getElementById("key").style.color = color;
+    } else { 
+    	// Possibly handle non-character-keys differently.
+    }
     return false;
 });

--- a/renderer.js
+++ b/renderer.js
@@ -8,7 +8,7 @@ document.body.addEventListener('keydown', function(e) {
     e.preventDefault();
     if (e.key.length < 2){
         document.getElementById('key').innerHTML = e.key;
-	const charCode = e.key.charCodeAt(0);
+        const charCode = e.key.charCodeAt(0);
         const color = colorMap[charCode % 7];
         document.getElementById('key').style.color = color;
     }


### PR DESCRIPTION
Keys are now colored based on unicode number.
Font changed from ‘Bangers’ to ‘Arvo.’
Font size of ‘Key’ div changed from 60vw to 30vw.
Modifier keys (e.g. Shift, Ctrl) are no longer displayed.
